### PR TITLE
display filter small bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sedpy/*~
 sedpy/*.pyc
 junk*
 *~
+
+*.egg-info/

--- a/sedpy/observate.py
+++ b/sedpy/observate.py
@@ -260,8 +260,7 @@ class Filter(object):
             if ax is None:
                 import matplotlib.pyplot as pl
                 fig, ax = pl.subplots()
-                ax.title(self.nick)
-                fig.show()
+                ax.set_title(self.nick)
             if normalize:
                 ax.plot(self.wavelength, self.transmission / self.transmission.max())
             else:


### PR DESCRIPTION
This is a very small bug: ax.title should be ax.set_title. 

I also deleted fig.show(), which seemed inconsistent with the option of passing in the axis (ie, ax != None) and it throws a warning when using Jupyter. 

Finally, I added *egg-info to the .gitignore file for development.  

This is great software! Thanks @bd-j!