### PR TITLE
implement FilterSet for faster projections

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -60,6 +60,13 @@ def test_gridded_filters():
     assert np.allclose(m_grid, m_default, atol=5e-2)
 
 
+def test_filterset():
+    from sedpy.observate import FilterSet
+    fnames = observate.list_available_filters()
+    filterset = FilterSet(fnames)
+    pass
+
+
 def test_filter_properties():
     """Compare to the values obtained from the K-correct code
     (which uses a slightly different Vega spectrum)


### PR DESCRIPTION
Work in Progress

this PR implements FilterSet objects, which enable faster projections for a set of Filter objects by pre-caching a number of useful arrays for a fixed global wavelength grid and avoiding costly loops of `observate.getSED`