### PR TITLE
pkg_resources Deprecation Fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "Simple tools for astronomical spectral energy distributions, part
 authors = [{ name = "Benjamin Johnson", email = "benjamin.johnson@cfa.harvard.edu" }]
 readme = "README.rst"
 license = { text = "MIT License" }
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -11,9 +12,18 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
-dependencies = ["numpy", "astropy"]
+dependencies = [
+    "numpy", 
+    "astropy"
+]
 
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm"]

--- a/sedpy/observate.py
+++ b/sedpy/observate.py
@@ -13,10 +13,7 @@ except(ImportError):
     from numpy import trapz as trapezoid
 
 import os
-try:
-    from pkg_resources import resource_filename, resource_listdir
-except(ImportError):
-    pass
+from importlib.resources import files
 from .reference_spectra import vega, solar, sedpydir
 
 
@@ -90,8 +87,9 @@ class Filter(object):
         if directory is None:
             loc = os.path.join('data', 'filters', kname + '.par')
             try:
-                self.filename = resource_filename("sedpy", loc)
-            except:
+                data_files = files('sedpy') / 'data' / 'filters'
+                self.filename = str(data_files / (kname + '.par'))
+            except Exception:
                 self.filename = os.path.join(sedpydir, loc)
         else:
             self.filename = os.path.join(directory, kname+'.par')
@@ -815,11 +813,12 @@ def list_available_filters():
     have been installed in the sedpy/data/filters/ directory.
     """
     try:
-        names = resource_listdir('sedpy', '/data/filters/')
-    except:
-        names = os.listdir(os.path.join(sedpydir, '/data/filters/'))
+        data_files = files('sedpy') / 'data' / 'filters'
+        names = [f.name for f in data_files.iterdir() if f.is_file()]
+    except Exception:
+        names = os.listdir(os.path.join(sedpydir, 'data', 'filters'))
 
-    parfiles = [n.replace('.par', '') for n in names if n[-4:] == '.par']
+    parfiles = [n.replace('.par', '') for n in names if n.endswith('.par')]
     parfiles.sort()
     return parfiles
 

--- a/sedpy/reference_spectra.py
+++ b/sedpy/reference_spectra.py
@@ -7,10 +7,7 @@ Units of the reference spectra are AA and erg/s/cm^2/AA
 
 import numpy as np
 import os
-try:
-    from pkg_resources import resource_filename
-except ImportError:
-    pass
+from importlib.resources import files
 try:
     import astropy.io.fits as pyfits
 except ImportError:
@@ -28,8 +25,9 @@ try:
     # This is from stsci calspec database ("calspec_ascii_review")
     # C.f. https://ui.adsabs.harvard.edu/abs/2007ASPC..364..315B/abstract
     # C.f. https://ui.adsabs.harvard.edu/abs/2014AJ....147..127B/abstract
-    vega_file = resource_filename('sedpy', 'data/alpha_lyr_stis_005.fits')
-except:
+    data_files = files('sedpy') / 'data'
+    vega_file = str(data_files / 'alpha_lyr_stis_005.fits')
+except Exception:
     vega_file = os.path.join(sedpydir, 'data', 'alpha_lyr_stis_005.fits')
 
 # This file should be in AA and erg/s/cm^2/AA
@@ -43,8 +41,9 @@ else:
                      'spectrum at {0}'.format(vega_file))
 
 try:
-    solar_file = resource_filename('sedpy', 'data/sun_kurucz93.fits')
-except:
+    data_files = files('sedpy') / 'data'
+    solar_file = str(data_files / 'sun_kurucz93.fits')
+except Exception:
     solar_file = os.path.join(sedpydir, 'data', 'sun_kurucz93.fits')
 
 # conversion to d=10 pc from 1 AU


### PR DESCRIPTION
pkg_resources is deprecated and will be removed in future versions of Python 3.12 and 3.13 (and onward). 
I have updated the code to use the recommended importlib implementation. 
However, this has the side effect of requiring a minimum Python version of 3.9 for sedpy. 
I defer to the maintainer to decide the best way forward, but this would still leave sedpy v4.0 compatible with older versions of Python, but require future versions of sedpy be on Python versions which are not EOL. 